### PR TITLE
Fix display of pluginfiles in intro

### DIFF
--- a/view.php
+++ b/view.php
@@ -159,7 +159,7 @@ echo $OUTPUT->heading(format_string($groupselect->name, true, array('context'=>$
 
 if (trim(strip_tags($groupselect->intro))) {
     echo $OUTPUT->box_start('mod_introbox', 'groupselectintro');
-    echo format_module_intro('page', $groupselect, $cm->id);
+    echo format_module_intro('groupselect', $groupselect, $cm->id);
     echo $OUTPUT->box_end();
 }
 


### PR DESCRIPTION
First argument to format_module_intro needs to match the source module so the pluginfile url's get generated correctly.
